### PR TITLE
Added fallback for unexpected HTTP errors

### DIFF
--- a/src/hibp.js
+++ b/src/hibp.js
@@ -50,6 +50,8 @@ const hibp = {
                 throw new Error(ERR403);
               case 404:
                 return null;
+              default:
+                throw new Error(err.response.data);
             }
           } else {
             throw err;

--- a/test/hibp.test.js
+++ b/test/hibp.test.js
@@ -4,6 +4,7 @@ import hibp from '../src/hibp';
 import {
     ERR,
     INVALID_HEADER,
+    UNKNOWN_ERROR,
     ACCOUNT_BREACHED,
     ACCOUNT_CLEAN,
     BREACH_FOUND,
@@ -158,6 +159,22 @@ describe('hibp', () => {
             expect(errorHandler.calledOnce).to.be(true);
             const err = errorHandler.getCall(0).args[0];
             expect(err.message).to.match(/^Forbidden/);
+          });
+    });
+  });
+
+  describe('breachedAccount (unexpected HTTP error)', () => {
+    it('should throw an Error width the error text from the request', () => {
+      const handler = sinon.spy();
+      const errorHandler = sinon.spy();
+      return hibp.breachedAccount(UNKNOWN_ERROR)
+          .then(handler)
+          .catch(errorHandler)
+          .then(() => {
+            expect(handler.called).to.be(false);
+            expect(errorHandler.calledOnce).to.be(true);
+            const err = errorHandler.getCall(0).args[0];
+            expect(err.message).to.match(/^Qux/);
           });
     });
   });

--- a/test/setup.js
+++ b/test/setup.js
@@ -10,10 +10,12 @@ const STATUS_200 = 200;
 const STATUS_400 = 400;
 const STATUS_403 = 403;
 const STATUS_404 = 404;
+const STATUS_456 = 456;
 const DOMAIN = 'foo.bar';
 
 export const ERR = new Error('Set sail for fail!');
 export const INVALID_HEADER = 'baz';
+export const UNKNOWN_ERROR = 'qux';
 export const ACCOUNT_BREACHED = 'foo';
 export const ACCOUNT_CLEAN = 'bar';
 export const BREACH_FOUND = 'foo';
@@ -44,6 +46,11 @@ before(() => {
   moxios.stubRequest(
       new RegExp(`/breachedaccount/${INVALID_HEADER}\\??`), {
         status: STATUS_403
+      });
+  moxios.stubRequest(
+      new RegExp(`/breachedaccount/${UNKNOWN_ERROR}\\??`), {
+        status: STATUS_456,
+        response: 'Qux'
       });
   moxios.stubRequest(
       new RegExp('/breaches\\??'), {


### PR DESCRIPTION
I ran into a problem where I was getting a HTTP error 429 (Too many requests) because I was trying to check two accounts at once. The `_fetchFromApi` did not catch these errors because they were not specified in the switch statement. To prevent this from happening I added a default case to catch all 'unexpected' HTTP errors, because you can never be 100% sure what a webserver throws at you.

Of course, this particular solution seemed the best solution to me, but if you'd prefer to handle this in a different way, let me know :)