### PR TITLE
Support tree-shaking bundlers via ES module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,49 @@
 {
   "env": {
+    "es": {
+      "presets": [
+        [
+          "env",
+          {
+            "modules": false,
+            "targets": {
+              "node": 4
+            }
+          }
+        ]
+      ]
+    },
+    "commonjs": {
+      "plugins": [
+        "add-module-exports"
+      ],
+      "presets": [
+        [
+          "env",
+          {
+            "modules": "commonjs",
+            "targets": {
+              "node": 4
+            }
+          }
+        ]
+      ]
+    },
     "test": {
       "plugins": [
         "istanbul"
+      ],
+      "presets": [
+        [
+          "env",
+          {
+            "modules": "commonjs",
+            "targets": {
+              "node": 4
+            }
+          }
+        ]
       ]
     }
-  },
-  "plugins": [
-    "add-module-exports"
-  ],
-  "presets": [
-    [
-      "env",
-      {
-        "targets": {
-          "node": 4
-        }
-      }
-    ]
-  ]
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ sftp-config.json
 
 ### Babel output ###
 lib/
+es/
 
 
 ### Webpack output ###

--- a/package.json
+++ b/package.json
@@ -20,19 +20,20 @@
   "contributors": [],
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "browser": "dist/hibp.min.js",
   "runkitExampleFilename": "example/runkit.js",
   "scripts": {
-    "clean": "rimraf ./dist ./lib ./coverage ./nyc_output",
-    "build": "babel src --out-dir lib --source-maps",
+    "clean": "rimraf dist lib es coverage nyc_output",
+    "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
+    "build:commonjs": "cross-env NODE_ENV=production BABEL_ENV=commonjs babel src --out-dir lib --source-maps",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel src --out-dir es --source-maps",
+    "build:umd": "cross-env BABEL_ENV=commonjs webpack --progress --colors --hide-modules --config webpack/webpack.config.dev.babel.js",
+    "build:umd:min": "cross-env BABEL_ENV=commonjs webpack -p --progress --colors --hide-modules --config webpack/webpack.config.prod.babel.js",
     "lint": "eslint src test webpack",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
-    "postbuild": "npm run webpack",
-    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha",
-    "webpack": "npm run webpack:dev && npm run webpack:prod",
-    "webpack:dev": "webpack --progress --colors --hide-modules --config webpack/webpack.config.dev.babel.js",
-    "webpack:prod": "webpack -p --progress --colors --hide-modules --config webpack/webpack.config.prod.babel.js"
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Bundlers like rollup and webpack should read the "module" field in
  package.json and load the ES module version of the output.
* The repetition here in .babelrc sucks, but it can probably be
  remedied once Babel 7 is released with .babelrc.js support.