### PR TITLE
Remove the top-level default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Browser via CDN (see [below](#using-in-the-browser) for more information):
 import { dataClasses, search } from 'hibp';
 // or, import all modules into a local namespace
 import * as hibp from 'hibp';
-// or, import the default export (warning: prevents tree-shaking)
-import hibp from 'hibp';
 
 /* CommonJS module syntax */
 

--- a/src/hibp.js
+++ b/src/hibp.js
@@ -31,17 +31,3 @@ export {
   pasteAccount,
   search,
 };
-
-/*
- * Export the hibp namespace as the default export to allow the following:
- *
- * import hibp from 'hibp'; // ESM (without tree-shaking!)
- */
-export default {
-  breach,
-  breachedAccount,
-  breaches,
-  dataClasses,
-  pasteAccount,
-  search,
-};

--- a/test/hibp.test.js
+++ b/test/hibp.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import hibp from '../src/hibp';
+import * as hibp from '../src/hibp';
 
 describe('hibp', () => {
   it('should export an object containing the advertised functions', () => {

--- a/webpack/webpack.config.base.babel.js
+++ b/webpack/webpack.config.base.babel.js
@@ -13,7 +13,6 @@ export default {
   output: {
     library: 'hibp',
     libraryTarget: 'umd',
-    libraryExport: 'default',
     umdNamedDefine: true,
     path: path.join(projectRoot, 'dist'),
   },


### PR DESCRIPTION
The mere presence of the default export appears to break webpack
tree-shaking. Also, it has been suggested by Dr. Axel Rauschmayer
that exporting an object as the "default"-named export is probably
an anti-pattern when all you want to do is provide access to its
properties (https://goo.gl/cXCS2D).

Closes #13.