### PR TITLE
build(ts): remove absolute module resolution from TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*", "src/*", "src/__mocks__/*"]
-    },
     "lib": ["esnext"],
     "target": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
This was missed in #119.