### PR TITLE
chore(node): drop Node 8 support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,7 +9,7 @@ module.exports = {
         modules: test ? 'commonjs' : false,
         targets: {
           browsers: ['> 1%', 'last 2 versions'],
-          node: 8,
+          node: 10,
         },
       },
     ],

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 ## Migration Notes
 
+#### 8.0.1 → 9.0.0
+
+- Support for Node.js version 8.x has been dropped. You must upgrade your
+  Node.js environment to at least v10.
+
 #### 7.5.2 → 8.0.0
 
 - The `breachedAccount`, `pasteAccount`, and `search` modules now have an

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "homepage": "https://wkovacs64.github.io/hibp",
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">= 10"
   },
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Support for Node.js version 8.x has been dropped.