### PR TITLE
chore(node): drop Node 10 support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,7 +9,7 @@ module.exports = {
         modules: test ? 'commonjs' : false,
         targets: {
           browsers: ['> 1%', 'last 2 versions'],
-          node: 10,
+          node: '12.16',
         },
       },
     ],

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 ## Migration Notes
 
+#### 9.0.3 → 10.0.0
+
+- Support for Node.js version 10.x has been dropped. You must upgrade your
+  Node.js environment to at least v12.16.0.
+
 #### 8.0.1 → 9.0.0
 
 - Output files for all build targets have been consolidated under the `dist`

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "homepage": "https://wkovacs64.github.io/hibp",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12.16"
   },
   "dependencies": {
     "isomorphic-unfetch": "^3.1.0",


### PR DESCRIPTION
BREAKING CHANGE: Support for Node.js version 10.x has been dropped.