### PR TITLE
feat: update build output and add exports map

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,12 +1,12 @@
 module.exports = [
   // Pre-bundled for Browser (UMD)
   {
-    path: 'dist/browser/hibp.umd.min.js',
+    path: 'dist/browser/hibp.umd.js',
     limit: '5.25 KB',
   },
   // Pre-bundled for Browser (ESM)
   {
-    path: 'dist/browser/hibp.esm.min.js',
+    path: 'dist/browser/hibp.module.js',
     limit: '4.75 KB',
   },
   // Bundled with Webpack (CJS)
@@ -44,35 +44,35 @@ module.exports = [
   },
   // Bundled with Webpack (ESM)
   {
-    path: 'dist/esm/breach.js',
+    path: 'dist/esm/breach.mjs',
     limit: '1.1 KB',
   },
   {
-    path: 'dist/esm/breachedAccount.js',
+    path: 'dist/esm/breachedAccount.mjs',
     limit: '1.1 KB',
   },
   {
-    path: 'dist/esm/breaches.js',
+    path: 'dist/esm/breaches.mjs',
     limit: '1.1 KB',
   },
   {
-    path: 'dist/esm/dataClasses.js',
+    path: 'dist/esm/dataClasses.mjs',
     limit: '1.1 KB',
   },
   {
-    path: 'dist/esm/pasteAccount.js',
+    path: 'dist/esm/pasteAccount.mjs',
     limit: '1.1 KB',
   },
   {
-    path: 'dist/esm/pwnedPassword.js',
+    path: 'dist/esm/pwnedPassword.mjs',
     limit: '4.1 KB',
   },
   {
-    path: 'dist/esm/pwnedPasswordRange.js',
+    path: 'dist/esm/pwnedPasswordRange.mjs',
     limit: '1 KB',
   },
   {
-    path: 'dist/esm/search.js',
+    path: 'dist/esm/search.mjs',
     limit: '1.7 KB',
   },
 ];

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,23 @@
 
 #### 9.0.3 → 10.0.0
 
+- The production/minified versions of the browser build targets have been
+  renamed:
+
+  - ESM for Browsers (`<script type="module">`)
+    - `dist/browser/hibp.esm.min.js` → `dist/browser/hibp.module.js`
+  - UMD
+    - `dist/browser/hibp.umd.min.js` → `dist/browser/hibp.umd.js`
+
+- The development/non-minified versions of the UMD and ESM for browsers build
+  targets have been removed. If you were using them, please update your imports
+  to use the production/minified versions (see above).
+
+- The internal directory structure of the source code is now being preserved in
+  the CJS and ESM for bundlers build outputs (`dist/cjs` and `dist/esm`). If you
+  were deep importing anything you probably shouldn't have been (:wink:), you
+  may need to update your imports.
+
 - Support for Node.js version 10.x has been dropped. You must upgrade your
   Node.js environment to at least v12.16.0.
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,6 @@ You have several options for using this library in a browser environment:
    <script src="https://unpkg.com/hibp@x.y.z"></script>
    ```
 
-   Development and production (minified) UMD builds are also provided for manual
-   download if desired:
-
-   - [https://unpkg.com/hibp/dist/browser/hibp.umd.js][cdn-umd-dev]
-   - [https://unpkg.com/hibp/dist/browser/hibp.umd.min.js][cdn-umd-prod]
-
 1. ESM for Browsers
 
    Modern browsers now [support][caniuse-esm] importing ECMAScript modules via
@@ -156,7 +150,7 @@ You have several options for using this library in a browser environment:
    ```html
    <script type="module">
      // Replace x.y.z with the desired hibp version      ↓ ↓ ↓
-     import { dataClasses } from 'https://unpkg.com/hibp@x.y.z/dist/browser/hibp.esm.min.js';
+     import { dataClasses } from 'https://unpkg.com/hibp@x.y.z/dist/browser/hibp.module.js';
 
      const logDataClasses = async () => {
        console.table(await dataClasses());
@@ -165,12 +159,6 @@ You have several options for using this library in a browser environment:
      logDataClasses();
    </script>
    ```
-
-   Development and production (minified) ESM builds are also provided for manual
-   download if desired:
-
-   - [https://unpkg.com/hibp/dist/browser/hibp.esm.js][cdn-browser-esm-dev]
-   - [https://unpkg.com/hibp/dist/browser/hibp.esm.min.js][cdn-browser-esm-prod]
 
    For more information on ESM in the browser, check out [Using JS modules in
    the browser][js-modules].
@@ -219,11 +207,7 @@ This module is distributed under the [MIT License][license].
   https://www.troyhunt.com/authentication-and-the-have-i-been-pwned-api/
 [get-api-key]: https://haveibeenpwned.com/API/Key
 [unpkg]: https://unpkg.com
-[cdn-umd-dev]: https://unpkg.com/hibp/dist/browser/hibp.umd.js
-[cdn-umd-prod]: https://unpkg.com/hibp/dist/browser/hibp.umd.min.js
 [caniuse-esm]: https://caniuse.com/#feat=es6-module
-[cdn-browser-esm-dev]: https://unpkg.com/hibp/dist/browser/hibp.esm.js
-[cdn-browser-esm-prod]: https://unpkg.com/hibp/dist/browser/hibp.esm.min.js
 [js-modules]: https://v8.dev/features/modules#browser
 [webpack]: https://webpack.js.org
 [caniuse-promise]: https://caniuse.com/#search=promise

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,13 +137,6 @@ You have several options for using this library in a browser environment:
    <script src="https://unpkg.com/hibp@x.y.z"></script>
    ```
 
-   Development and production (minified) UMD builds are also provided for manual
-   download if desired:
-
-   - [https://unpkg.com/hibp/dist/browser/hibp.umd.js](https://unpkg.com/hibp/dist/browser/hibp.umd.js)
-   - [https://unpkg.com/hibp/dist/browser/hibp.umd.min.js](https://unpkg.com/hibp/dist/browser/hibp.umd.min.js)
-     <br><br>
-
 1. ESM for Browsers
 
    Modern browsers now [support](https://caniuse.com/#feat=es6-module) importing
@@ -155,7 +148,7 @@ You have several options for using this library in a browser environment:
    ```html
    <script type="module">
      // Replace x.y.z with the desired hibp version      ↓ ↓ ↓
-     import { dataClasses } from 'https://unpkg.com/hibp@x.y.z/dist/browser/hibp.esm.min.js';
+     import { dataClasses } from 'https://unpkg.com/hibp@x.y.z/dist/browser/hibp.module.js';
 
      const logDataClasses = async () => {
        console.table(await dataClasses());
@@ -164,12 +157,6 @@ You have several options for using this library in a browser environment:
      logDataClasses();
    </script>
    ```
-
-   Development and production (minified) ESM builds are also provided for manual
-   download if desired:
-
-   - [https://unpkg.com/hibp/dist/browser/hibp.esm.js](https://unpkg.com/hibp/dist/browser/hibp.esm.js)
-   - [https://unpkg.com/hibp/dist/browser/hibp.esm.min.js](https://unpkg.com/hibp/dist/browser/hibp.esm.min.js)
 
    For more information on ESM in the browser, check out
    [Using JS modules in the browser](https://v8.dev/features/modules#browser).

--- a/package.json
+++ b/package.json
@@ -25,9 +25,19 @@
     }
   ],
   "license": "MIT",
+  "exports": {
+    ".": {
+      "browser": "./dist/browser/hibp.module.js",
+      "umd": "./dist/browser/hibp.umd.js",
+      "require": "./dist/cjs/hibp.js",
+      "import": "./dist/esm/hibp.mjs"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "main": "dist/cjs/hibp.js",
-  "module": "dist/esm/hibp.js",
-  "unpkg": "dist/browser/hibp.umd.min.js",
+  "module": "dist/esm/hibp.mjs",
+  "unpkg": "dist/browser/hibp.umd.js",
   "types": "dist/hibp.d.ts",
   "runkitExampleFilename": "example/runkit.js",
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,6 +41,8 @@ export default [
       format: 'cjs',
       sourcemap: true,
       indent: false,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
     },
     external,
     plugins: [
@@ -50,14 +52,17 @@ export default [
     ],
   },
 
-  // ESM
+  // ESM for Bundlers
   {
     input: inputs,
     output: {
       dir: 'dist/esm',
+      entryFileNames: '[name].mjs',
       format: 'esm',
       sourcemap: true,
       indent: false,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
     },
     external,
     plugins: [
@@ -67,29 +72,11 @@ export default [
     ],
   },
 
-  // ESM for Browsers (development)
+  // ESM for Browsers
   {
     input: 'src/hibp.ts',
     output: {
-      file: 'dist/browser/hibp.esm.js',
-      format: 'esm',
-      sourcemap: true,
-      indent: false,
-    },
-    plugins: [
-      json({ preferConst: true }),
-      nodeResolve(nodeResolveOpts),
-      commonjs(),
-      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
-      typescript(typescriptOpts),
-    ],
-  },
-
-  // ESM for Browsers (production)
-  {
-    input: 'src/hibp.ts',
-    output: {
-      file: 'dist/browser/hibp.esm.min.js',
+      file: 'dist/browser/hibp.module.js',
       format: 'esm',
       sourcemap: true,
       indent: false,
@@ -104,30 +91,11 @@ export default [
     ],
   },
 
-  // UMD (development)
+  // UMD
   {
     input: 'src/hibp.ts',
     output: {
       file: 'dist/browser/hibp.umd.js',
-      format: 'umd',
-      name: umdName,
-      sourcemap: true,
-    },
-    plugins: [
-      json({ preferConst: true }),
-      babel(babelOpts),
-      nodeResolve(nodeResolveOpts),
-      commonjs(),
-      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
-      typescript(typescriptOpts),
-    ],
-  },
-
-  // UMD (production)
-  {
-    input: 'src/hibp.ts',
-    output: {
-      file: 'dist/browser/hibp.umd.min.js',
       format: 'umd',
       name: umdName,
       sourcemap: true,

--- a/src/search.ts
+++ b/src/search.ts
@@ -97,8 +97,11 @@ export function search(
     /^.+@.+$/.test(account)
       ? pasteAccount(account, { apiKey, baseUrl, userAgent })
       : null,
-  ]).then(([breaches, pastes]) => ({
-    breaches,
-    pastes,
-  }));
+  ]).then(
+    // Avoid array destructuring here to prevent need for Babel helpers
+    (promises) => ({
+      breaches: promises[0],
+      pastes: promises[1],
+    }),
+  );
 }

--- a/test/esm.html
+++ b/test/esm.html
@@ -15,7 +15,7 @@
     <p>Test Results: <span id="results">failed (or incomplete)</span></p>
 
     <script type="module">
-      import * as hibp from '../dist/browser/hibp.esm.min.js';
+      import * as hibp from '../dist/browser/hibp.module.js';
 
       if (typeof hibp !== 'object') throw new Error();
       if (typeof hibp.breach !== 'function') throw new Error();

--- a/test/umd.html
+++ b/test/umd.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>UMD Test</title>
-    <script src="../dist/browser/hibp.umd.min.js"></script>
+    <script src="../dist/browser/hibp.umd.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This is a combination of related changes attempting to further modernize the package.

BREAKING CHANGE: Node.js >= 12.16.0 respects the `exports` map and prevents access to any files not
explicitly exposed therein. If you are in such an environment and accessing specific files via deep
imports, you may be affected. Please open an issue if this is a problem for you.

BREAKING CHANGE: The internal directory structure of the module is now being preserved in the CJS
and ESM for bundlers build outputs (`dist/cjs` and `dist/esm`). If you were deep importing anything
you probably shouldn't have been (:wink:), you may need to update your imports.

BREAKING CHANGE: The development/non-minified versions of the UMD and ESM for browsers build targets
have been removed. As far as I can tell, nobody cares about these. If _you_ do, please open an issue
and I'll bring them back.

BREAKING CHANGE: The production/minified versions of the browser build targets have been renamed:
  - ESM for Browsers (`<script type="module">`)
    - `dist/browser/hibp.esm.min.js` → `dist/browser/hibp.module.js`
  - UMD
    - `dist/browser/hibp.umd.min.js` → `dist/browser/hibp.umd.js`