### PR TITLE
feat: return an object from pwnedPasswordRange

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
   // Pre-bundled for Browser (UMD)
   {
     path: 'dist/browser/hibp.umd.js',
-    limit: '5.3 kB',
+    limit: '5.7 kB',
   },
   // Pre-bundled for Browser (ESM)
   {

--- a/API.md
+++ b/API.md
@@ -33,7 +33,7 @@ valid API key on your behalf) will fail.</p>
 breach (0 indicating no exposure). The password is given in plain text, but
 only the first 5 characters of its SHA-1 hash will be submitted to the API.</p>
 </dd>
-<dt><a href="#pwnedPasswordRange">pwnedPasswordRange(prefix, [options])</a> ⇒ <code><a href="#pwnedpasswordsuffix--object">Promise.&lt;Array.&lt;PwnedPasswordSuffix&gt;&gt;</a></code></dt>
+<dt><a href="#pwnedPasswordRange">pwnedPasswordRange(prefix, [options])</a> ⇒ <code><a href="#PwnedPasswordSuffixes">Promise.&lt;PwnedPasswordSuffixes&gt;</a></code></dt>
 <dd><p>Fetches the SHA-1 hash suffixes for the given 5-character SHA-1 hash prefix.</p>
 <p>When a password hash with the same first 5 characters is found in the Pwned
 Passwords repository, the API will respond with an HTTP 200 and include the
@@ -67,10 +67,9 @@ required, but direct requests made without it (that is, without specifying a
 <dt><a href="#Paste">Paste</a> : <code>object</code></dt>
 <dd><p>An object representing a paste.</p>
 </dd>
-<dt><a href="#PwnedPasswordSuffix">PwnedPasswordSuffix</a> : <code>object</code></dt>
-<dd><p>An object representing an exposed password hash suffix (corresponding to a
-given hash prefix) and how many times it occurred in the Pwned Passwords
-repository.</p>
+<dt><a href="#PwnedPasswordSuffixes">PwnedPasswordSuffixes</a> : <code>Object.&lt;string, number&gt;</code></dt>
+<dd><p>An object mapping an exposed password hash suffix (corresponding to a given
+hash prefix) to how many times it occurred in the Pwned Passwords repository.</p>
 </dd>
 <dt><a href="#SearchResults">SearchResults</a> : <code>object</code></dt>
 <dd><p>An object representing search results.</p>
@@ -337,7 +336,7 @@ pwnedPassword('f00b4r')
 ```
 <a name="pwnedPasswordRange"></a>
 
-## pwnedPasswordRange(prefix, [options]) ⇒ <code><a href="#pwnedpasswordsuffix--object">Promise.&lt;Array.&lt;PwnedPasswordSuffix&gt;&gt;</a></code>
+## pwnedPasswordRange(prefix, [options]) ⇒ [<code>Promise.&lt;PwnedPasswordSuffixes&gt;</code>](#PwnedPasswordSuffixes)
 Fetches the SHA-1 hash suffixes for the given 5-character SHA-1 hash prefix.
 
 When a password hash with the same first 5 characters is found in the Pwned
@@ -347,10 +346,10 @@ of how many times it appears in the data set. This function parses the
 response and returns a more structured format.
 
 **Kind**: global function  
-**Returns**: <code><a href="#pwnedpasswordsuffix--object">Promise.&lt;Array.&lt;PwnedPasswordSuffix&gt;&gt;</a></code> - a Promise which resolves to an
-array of objects, each containing the `suffix` that when matched with the
-prefix composes the complete hash, and a `count` of how many times it appears
-in the breached password data set, or rejects with an Error  
+**Returns**: [<code>Promise.&lt;PwnedPasswordSuffixes&gt;</code>](#PwnedPasswordSuffixes) - a Promise which resolves to an
+object mapping the `suffix` that when matched with the prefix composes the
+complete hash, to the `count` of how many times it appears in the breached
+password data set, or rejects with an Error  
 **See**: https://haveibeenpwned.com/api/v3#SearchingPwnedPasswordsByRange  
 
 | Param | Type | Description |
@@ -365,21 +364,18 @@ in the breached password data set, or rejects with an Error
 pwnedPasswordRange('5BAA6')
   .then(results => {
     // results will have the following shape:
-    // [
-    //   { suffix: "003D68EB55068C33ACE09247EE4C639306B", count: 3 },
-    //   { suffix: "012C192B2F16F82EA0EB9EF18D9D539B0DD", count: 1 },
+    // {
+    //   "003D68EB55068C33ACE09247EE4C639306B": 3,
+    //   "012C192B2F16F82EA0EB9EF18D9D539B0DD": 1,
     //   ...
-    // ]
+    // }
   })
 ```
 **Example**  
 ```js
 const suffix = '1E4C9B93F3F0682250B6CF8331B7EE68FD8';
 pwnedPasswordRange('5BAA6')
-  // filter to matching suffix
-  .then(results => results.filter(row => row.suffix === suffix))
-  // return count if match, 0 if not
-  .then(results => (results[0] ? results[0].count : 0))
+  .then(results => (results[suffix] || 0))
   .catch(err => {
     // ...
   });
@@ -490,21 +486,13 @@ An object representing a paste.
 | Date | <code>string</code> | 
 | EmailCount | <code>number</code> | 
 
-<a name="PwnedPasswordSuffix"></a>
+<a name="PwnedPasswordSuffixes"></a>
 
-## PwnedPasswordSuffix : <code>object</code>
-An object representing an exposed password hash suffix (corresponding to a
-given hash prefix) and how many times it occurred in the Pwned Passwords
-repository.
+## PwnedPasswordSuffixes : <code>Object.&lt;string, number&gt;</code>
+An object mapping an exposed password hash suffix (corresponding to a given
+hash prefix) to how many times it occurred in the Pwned Passwords repository.
 
 **Kind**: global typedef  
-**Properties**
-
-| Name | Type |
-| --- | --- |
-| suffix | <code>string</code> | 
-| count | <code>number</code> | 
-
 <a name="SearchResults"></a>
 
 ## SearchResults : <code>object</code>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,19 @@
 ## Migration Notes
 
+### 10.0.1 → 11.0.0
+
+- `pwnedPasswordRange` now returns an object mapping the matching suffix to a
+  count representing the number of occurrences, rather than an array of objects
+  each containing a matching suffix and its count. Code dependent on parsing the
+  response text will need updated to deal with the new data format:
+  ```js
+  {
+    "003D68EB55068C33ACE09247EE4C639306B": 3,
+    "012C192B2F16F82EA0EB9EF18D9D539B0DD": 1,
+    ...
+  }
+  ```
+
 #### 9.0.3 → 10.0.0
 
 - The production/minified versions of the browser build targets have been

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     {
       "name": "Daniel Adams",
       "email": "danieladams456@gmail.com"
+    }, {
+      "name": "Jonathan Sharpe",
+      "email": "mail@jonrshar.pe"
     }
   ],
   "license": "MIT",

--- a/src/__tests__/pwnedPassword.test.ts
+++ b/src/__tests__/pwnedPassword.test.ts
@@ -19,7 +19,7 @@ describe('pwnedPassword', () => {
     it('resolves to 0', () => {
       server.use(
         rest.get('*', (_, res, ctx) => {
-          return res(ctx.json(null));
+          return res(ctx.text(EXAMPLE_PASSWORD_HASHES));
         }),
       );
 

--- a/src/__tests__/pwnedPasswordRange.test.ts
+++ b/src/__tests__/pwnedPasswordRange.test.ts
@@ -4,27 +4,18 @@ import { pwnedPasswordRange } from '../pwnedPasswordRange';
 
 describe('pwnedPasswordRange', () => {
   describe('valid range', () => {
-    it('resolves with an array of objects', () => {
+    it('resolves with an object', () => {
       server.use(
         rest.get('*', (_, res, ctx) => {
           return res(ctx.text(EXAMPLE_PASSWORD_HASHES));
         }),
       );
 
-      return expect(pwnedPasswordRange('5BAA6')).resolves.toEqual([
-        {
-          suffix: '003D68EB55068C33ACE09247EE4C639306B',
-          count: 3,
-        },
-        {
-          suffix: '1E4C9B93F3F0682250B6CF8331B7EE68FD8',
-          count: 3303003,
-        },
-        {
-          suffix: '01330C689E5D64F660D6947A93AD634EF8F',
-          count: 1,
-        },
-      ]);
+      return expect(pwnedPasswordRange('5BAA6')).resolves.toEqual({
+        '003D68EB55068C33ACE09247EE4C639306B': 3,
+        '1E4C9B93F3F0682250B6CF8331B7EE68FD8': 3303003,
+        '01330C689E5D64F660D6947A93AD634EF8F': 1,
+      });
     });
   });
 });

--- a/src/pwnedPassword.ts
+++ b/src/pwnedPassword.ts
@@ -39,11 +39,7 @@ export function pwnedPassword(
   const prefix = hash.slice(0, 5);
   const suffix = hash.slice(5);
 
-  return (
-    pwnedPasswordRange(prefix, options)
-      // filter to matching suffix
-      .then((arr) => arr.filter((item) => item.suffix === suffix))
-      // return count if match, 0 if not
-      .then((arr) => (arr[0] ? arr[0].count : 0))
+  return pwnedPasswordRange(prefix, options).then(
+    (range) => range[suffix] || 0,
   );
 }

--- a/src/pwnedPasswordRange.ts
+++ b/src/pwnedPasswordRange.ts
@@ -1,6 +1,6 @@
 import { fetchFromApi } from './api/pwnedpasswords';
 
-export interface PwnedPasswordSuffix {
+export interface PwnedPasswordSuffixes {
   [suffix: string]: number;
 }
 
@@ -8,7 +8,7 @@ export interface PwnedPasswordSuffix {
  * An object mapping an exposed password hash suffix (corresponding to a given
  * hash prefix) to how many times it occurred in the Pwned Passwords repository.
  *
- * @typedef {Object.<string, number>} PwnedPasswordSuffix
+ * @typedef {Object.<string, number>} PwnedPasswordSuffixes
  */
 
 /**
@@ -27,10 +27,10 @@ export interface PwnedPasswordSuffix {
  * pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
- * @returns {Promise<PwnedPasswordSuffix>} a Promise which resolves to an object
- * mapping the `suffix` that when matched with the prefix composes the complete
- * hash, to the `count` of how many times it appears in the breached password
- * data set, or rejects with an Error
+ * @returns {Promise<PwnedPasswordSuffixes>} a Promise which resolves to an
+ * object mapping the `suffix` that when matched with the prefix composes the
+ * complete hash, to the `count` of how many times it appears in the breached
+ * password data set, or rejects with an Error
  *
  * @example
  * pwnedPasswordRange('5BAA6')
@@ -54,14 +54,14 @@ export interface PwnedPasswordSuffix {
 export function pwnedPasswordRange(
   prefix: string,
   options: { baseUrl?: string; userAgent?: string } = {},
-): Promise<PwnedPasswordSuffix> {
+): Promise<PwnedPasswordSuffixes> {
   return (
     fetchFromApi(`/range/${encodeURIComponent(prefix)}`, options)
       // create array from lines of text in response body
       .then((data) => data.split('\n'))
       // convert into an object mapping suffix to count for each line
       .then((results) =>
-        results.reduce<PwnedPasswordSuffix>((acc, row) => {
+        results.reduce<PwnedPasswordSuffixes>((acc, row) => {
           const [suffix, countString] = row.split(':');
           acc[suffix] = parseInt(countString, 10);
           return acc;


### PR DESCRIPTION
Return an object mapping the matching suffix to a count representing the number of occurrences, rather than an array of objects each containing a matching suffix and its count. Closes #218.

BREAKING CHANGE: the return type of `pwnedPasswordRange` is now an object, not an array.