### PR TITLE
feat: add 'retryAfterSeconds' property to thrown rate limit errors

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -3,12 +3,12 @@ module.exports = {
     // Pre-bundled for Browser (UMD)
     {
       path: 'dist/browser/hibp.umd.js',
-      maxSize: '5.9 kB',
+      maxSize: '6.2 kB',
     },
     // Pre-bundled for Browser (ESM)
     {
       path: 'dist/browser/hibp.module.js',
-      maxSize: '4.7 kB',
+      maxSize: '4.9 kB',
     },
     // Bundled with Webpack (CJS)
     {

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ search('someAccountOrEmail', { apiKey: 'my-api-key' })
   });
 ```
 
+#### Rate Limiting
+
+The haveibeenpwned.com API [rate limits][haveibeenpwned-rate-limiting] requests
+to prevent abuse. In the event you get rate limited, the module will throw a
+custom `RateLimitError` which will include a `retryAfterSeconds` property so you
+know when you can try the call again (as a `number`, unless the remote API did
+not provide one, in which case it will be `undefined` - but that _should_ never
+happen).
+
 #### Using in the browser
 
 **Prerequisite:** This module requires a Promise implementation to exist in the
@@ -202,6 +211,7 @@ This module is distributed under the [MIT License][license].
 [skypack]: https://www.skypack.dev/
 [troy]: https://www.troyhunt.com
 [haveibeenpwned]: https://haveibeenpwned.com
+[haveibeenpwned-rate-limiting]: https://haveibeenpwned.com/API/v3#RateLimiting
 [search-by-range]:
   https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange
 [api-key-blog-post]:

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,16 @@ search('someAccountOrEmail', { apiKey: 'my-api-key' })
   });
 ```
 
+#### Rate Limiting
+
+The haveibeenpwned.com API
+[rate limits](https://haveibeenpwned.com/API/v3#RateLimiting) requests to
+prevent abuse. In the event you get rate limited, the module will throw a custom
+`RateLimitError` which will include a `retryAfterSeconds` property so you know
+when you can try the call again (as a `number`, unless the remote API did not
+provide one, in which case it will be `undefined` - but that _should_ never
+happen).
+
 #### Using in the browser
 
 **Prerequisite:** This module requires a Promise implementation to exist in the

--- a/src/__tests__/hibp.test.ts
+++ b/src/__tests__/hibp.test.ts
@@ -4,6 +4,7 @@ describe('hibp', () => {
   it('exports an object containing the advertised functions', () => {
     expect(hibp).toMatchInlineSnapshot(`
       {
+        "RateLimitError": [Function],
         "breach": [Function],
         "breachedAccount": [Function],
         "breaches": [Function],

--- a/src/api/haveibeenpwned/responses.ts
+++ b/src/api/haveibeenpwned/responses.ts
@@ -79,7 +79,7 @@ export const NOT_FOUND: HaveIBeenPwnedApiResponse = {
  * @internal
  */
 export const TOO_MANY_REQUESTS: HaveIBeenPwnedApiResponse = {
-  headers: emptyHeaders,
+  headers: new Map([['retry-after', '2']]),
   status: 429,
   body: {
     statusCode: 429,

--- a/src/hibp.ts
+++ b/src/hibp.ts
@@ -6,7 +6,7 @@ import { pasteAccount } from './pasteAccount';
 import { pwnedPassword } from './pwnedPassword';
 import { pwnedPasswordRange } from './pwnedPasswordRange';
 import { search } from './search';
-import { RateLimitError } from './api/haveibeenpwned/fetchFromApi';
+import { RateLimitError } from './api/haveibeenpwned';
 
 /*
  * Export individual named functions to allow the following:

--- a/src/hibp.ts
+++ b/src/hibp.ts
@@ -6,6 +6,7 @@ import { pasteAccount } from './pasteAccount';
 import { pwnedPassword } from './pwnedPassword';
 import { pwnedPasswordRange } from './pwnedPasswordRange';
 import { search } from './search';
+import { RateLimitError } from './api/haveibeenpwned/fetchFromApi';
 
 /*
  * Export individual named functions to allow the following:
@@ -25,6 +26,7 @@ export {
   pwnedPassword,
   pwnedPasswordRange,
   search,
+  RateLimitError,
 };
 
 // Export the overall interface, primarily for typing the `hibp` object placed
@@ -38,6 +40,7 @@ export interface HIBP {
   pwnedPassword: typeof pwnedPassword;
   pwnedPasswordRange: typeof pwnedPasswordRange;
   search: typeof search;
+  RateLimitError: typeof RateLimitError;
 }
 
 // https://github.com/jsdoc2md/jsdoc-to-markdown/wiki/How-to-document-TypeScript#jsdoc-comments-disappear


### PR DESCRIPTION
The haveibeenpwned.com API rate limits requests to prevent abuse. In the
event you get rate limited, the module will throw a custom
`RateLimitError` which will include a `retryAfterSeconds` property so
you know when you can try the call again (as a `number`, unless the
remote API did not provide one, in which case it will be `undefined` -
but that _should_ never happen).

Closes #303