### PR TITLE
support web workers using native fetch

### DIFF
--- a/.changeset/smart-deers-change.md
+++ b/.changeset/smart-deers-change.md
@@ -1,0 +1,5 @@
+---
+"hibp": patch
+---
+
+Add support for native fetch in web workers and extension background threads

--- a/src/api/web-fetch.ts
+++ b/src/api/web-fetch.ts
@@ -2,7 +2,7 @@
 // support for v18. https://x.com/ebey_jacob/status/1709975146939973909?s=20
 
 /* c8 ignore next */
-export default typeof window !== 'undefined' ? window.fetch : fetchWrapper;
+export default 'fetch' in globalThis ? fetch : fetchWrapper;
 
 async function fetchWrapper(
   input: string | URL,


### PR DESCRIPTION
Supports using native fetch in web workers or extension background threads where `window` is `undefined`.

Should still fall back to using `fetchWrapper` when native fetch is not available for older versions of NodeJS.

I ran vitest but it does not look like unit tests are passing. Perhaps I am missing some setup.

I ran the playwright tests and they did pass though.

#456 