### PR TITLE
Fix consumption from Next.js client components

### DIFF
--- a/.changeset/olive-pandas-buy.md
+++ b/.changeset/olive-pandas-buy.md
@@ -1,0 +1,5 @@
+---
+'hibp': patch
+---
+
+Fix consumption from Next.js client components.

--- a/src/api/fetch-polyfill.ts
+++ b/src/api/fetch-polyfill.ts
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
 // This can probably be removed in favor of Node's native fetch once we drop
 // support for v18. https://x.com/ebey_jacob/status/1709975146939973909?s=20
@@ -9,7 +10,7 @@
 export function installUndiciOnNode18() {
   if (
     typeof process !== 'undefined' &&
-    process.versions.node.startsWith('18.')
+    process.versions?.node?.startsWith('18.')
   ) {
     const {
       File: UndiciFile,


### PR DESCRIPTION
Apparently, `process` exists but `.versions.node` does not. Next.js may be doing something weird with `process` so we'll just be more cautious when testing for Node.js v18 in the `fetch` polyfill.

Fixes #463 