### PR TITLE
Add `IncludesStealerLogs` field to `SubscriptionStatus`

### DIFF
--- a/.changeset/stealer-logs-subscription-status.md
+++ b/.changeset/stealer-logs-subscription-status.md
@@ -1,0 +1,6 @@
+---
+'hibp': patch
+---
+
+Add `IncludesStealerLogs` field to `SubscriptionStatus` interface and docs.
+

--- a/API.md
+++ b/API.md
@@ -591,4 +591,5 @@ An object representing the status of your HIBP subscription.
 | SubscribedUntil | <code>string</code> | 
 | Rpm | <code>number</code> | 
 | DomainSearchMaxBreachedAccounts | <code>number</code> | 
+| IncludesStealerLogs | <code>boolean</code> | 
 

--- a/src/api/haveibeenpwned/types.ts
+++ b/src/api/haveibeenpwned/types.ts
@@ -36,6 +36,7 @@ export interface SubscriptionStatus {
   SubscribedUntil: string;
   Rpm: number;
   DomainSearchMaxBreachedAccounts: number;
+  IncludesStealerLogs: boolean;
 }
 
 //

--- a/src/subscription-status.ts
+++ b/src/subscription-status.ts
@@ -10,6 +10,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * @property {string} SubscribedUntil
  * @property {number} Rpm
  * @property {number} DomainSearchMaxBreachedAccounts
+ * @property {boolean} IncludesStealerLogs
  */
 
 /**

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -58,6 +58,7 @@ export const SUBSCRIPTION_STATUS: SubscriptionStatus = {
   SubscribedUntil: '2024-04-02T12:34:56',
   Rpm: 10,
   DomainSearchMaxBreachedAccounts: 25,
+  IncludesStealerLogs: false,
 };
 
 export const PASSWORD = 'password';


### PR DESCRIPTION
Add `IncludesStealerLogs` field to `SubscriptionStatus`.

Closes #533

---
<a href="https://cursor.com/background-agent?bcId=bc-5a5e3aef-123e-4dec-a1d8-92da554242d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a5e3aef-123e-4dec-a1d8-92da554242d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Subscription status now shows whether your plan includes stealer logs.

* Documentation
  * Updated API docs to describe the new subscription status flag.

* Tests
  * Updated fixtures to cover the new subscription status field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->