### PR TITLE
Implement `stealerLogsByEmail` module

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -53,6 +53,10 @@
     {
       "path": "dist/esm/subscribed-domains.js",
       "maxSize": "1.1 kB"
+    },
+    {
+      "path": "dist/esm/stealer-logs-by-email.js",
+      "maxSize": "1 kB"
     }
   ]
 }

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -47,7 +47,7 @@
       "maxSize": "1.4 kB"
     },
     {
-      "path": "dist/esm/subscription-status.js",
+      "path": "dist/esm/stealer-logs-by-email.js",
       "maxSize": "1 kB"
     },
     {
@@ -55,7 +55,7 @@
       "maxSize": "1.1 kB"
     },
     {
-      "path": "dist/esm/stealer-logs-by-email.js",
+      "path": "dist/esm/subscription-status.js",
       "maxSize": "1 kB"
     }
   ]

--- a/.changeset/add-stealer-logs-by-email-module.md
+++ b/.changeset/add-stealer-logs-by-email-module.md
@@ -1,0 +1,5 @@
+---
+'hibp': minor
+---
+
+Add `stealerLogsByEmail` module.

--- a/API.md
+++ b/API.md
@@ -69,7 +69,7 @@ convenience method is designed to mimic.</p>
 required, but direct requests made without it will fail (unless you specify a
 <code>baseUrl</code> to a proxy that inserts a valid API key on your behalf).</p>
 </dd>
-<dt><a href="#stealerLogsByEmail">stealerLogsByEmail(email, [options])</a> ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> | <code>Promise.&lt;null&gt;</code></dt>
+<dt><a href="#stealerLogsByEmail">stealerLogsByEmail(emailAddress, [options])</a> ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> | <code>Promise.&lt;null&gt;</code></dt>
 <dd><p>Fetches all stealer log domains for an email address.</p>
 <p>Returns an array of domains for which stealer logs contain entries for the
 supplied email address.</p>
@@ -587,7 +587,7 @@ try {
 ```
 <a name="stealerLogsByEmail"></a>
 
-## stealerLogsByEmail(email, [options]) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code>
+## stealerLogsByEmail(emailAddress, [options]) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code>
 Fetches all stealer log domains for an email address.
 
 Returns an array of domains for which stealer logs contain entries for the
@@ -606,7 +606,7 @@ Error
 
 | Param | Type | Description |
 | --- | --- | --- |
-| email | <code>string</code> | the email address to query |
+| emailAddress | <code>string</code> | the email address to query |
 | [options] | <code>object</code> | a configuration object |
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |

--- a/API.md
+++ b/API.md
@@ -69,6 +69,16 @@ convenience method is designed to mimic.</p>
 required, but direct requests made without it will fail (unless you specify a
 <code>baseUrl</code> to a proxy that inserts a valid API key on your behalf).</p>
 </dd>
+<dt><a href="#stealerLogsByEmail">stealerLogsByEmail(email, [options])</a> ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> | <code>Promise.&lt;null&gt;</code></dt>
+<dd><p>Fetches all stealer log domains for an email address.</p>
+<p>Returns an array of domains for which stealer logs contain entries for the
+supplied email address.</p>
+<p>🔑 <code>haveibeenpwned.com</code> requires an API key from
+<a href="https://haveibeenpwned.com/API/Key">https://haveibeenpwned.com/API/Key</a> for the <code>stealerlogsbyemail</code> endpoint. The
+<code>apiKey</code> option here is not explicitly required, but direct requests made
+without it will fail (unless you specify a <code>baseUrl</code> to a proxy that inserts
+a valid API key on your behalf).</p>
+</dd>
 <dt><a href="#subscribedDomains">subscribedDomains([options])</a> ⇒ <code><a href="#subscribeddomain--object">Promise.&lt;Array.&lt;SubscribedDomain&gt;&gt;</a></code></dt>
 <dd><p>Fetches all subscribed domains for your HIBP account.</p>
 <p>Returns domains that have been successfully added to the Domain Search dashboard
@@ -567,6 +577,62 @@ try {
     truncate: false,
   });
   if (data.breaches || data.pastes) {
+    // ...
+  } else {
+    // ...
+  }
+} catch (err) {
+  // ...
+}
+```
+<a name="stealerLogsByEmail"></a>
+
+## stealerLogsByEmail(email, [options]) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code>
+Fetches all stealer log domains for an email address.
+
+Returns an array of domains for which stealer logs contain entries for the
+supplied email address.
+
+🔑 `haveibeenpwned.com` requires an API key from
+https://haveibeenpwned.com/API/Key for the `stealerlogsbyemail` endpoint. The
+`apiKey` option here is not explicitly required, but direct requests made
+without it will fail (unless you specify a `baseUrl` to a proxy that inserts
+a valid API key on your behalf).
+
+**Kind**: global function  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code> - a Promise which resolves to an
+array of domain strings (or null if none were found), or rejects with an
+Error  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| email | <code>string</code> | the email address to query |
+| [options] | <code>object</code> | a configuration object |
+| [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
+| [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
+| [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
+
+**Example**  
+```js
+try {
+  const data = await stealerLogsByEmail("foo@bar.com", { apiKey: "my-api-key" });
+  if (data) {
+    // ...
+  } else {
+    // ...
+  }
+} catch (err) {
+  // ...
+}
+```
+**Example**  
+```js
+try {
+  const data = await stealerLogsByEmail("foo@bar.com", {
+    baseUrl: "https://my-hibp-proxy:8080",
+  });
+  if (data) {
     // ...
   } else {
     // ...

--- a/README.md
+++ b/README.md
@@ -66,15 +66,16 @@ The following modules are available:
 
 - [breach](API.md#breach)
 - [breachedAccount](API.md#breachedaccount)
-- [breaches](API.md#breaches)
 - [breachedDomain](API.md#breacheddomain)
+- [breaches](API.md#breaches)
 - [dataClasses](API.md#dataclasses)
 - [latestBreach](API.md#latestbreach)
 - [pasteAccount](API.md#pasteaccount)
-- [subscribedDomains](API.md#subscribeddomains)
 - [pwnedPassword](API.md#pwnedpassword)
 - [pwnedPasswordRange](API.md#pwnedpasswordrange)
 - [search](API.md#search)
+- [stealerLogsByEmail](API.md#stealerlogsbyemail)
+- [subscribedDomains](API.md#subscribeddomains)
 - [subscriptionStatus](API.md#subscriptionstatus)
 
 Please see the [API reference](API.md) for more detailed usage information and examples.

--- a/src/__tests__/hibp.test.ts
+++ b/src/__tests__/hibp.test.ts
@@ -16,6 +16,7 @@ describe('hibp', () => {
         "pwnedPassword": [Function],
         "pwnedPasswordRange": [Function],
         "search": [Function],
+        "stealerLogsByEmail": [Function],
         "subscribedDomains": [Function],
         "subscriptionStatus": [Function],
       }

--- a/src/__tests__/stealer-logs-by-email.test.ts
+++ b/src/__tests__/stealer-logs-by-email.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { http } from 'msw';
+import { server } from '../../mocks/server.js';
+import { NOT_FOUND } from '../api/haveibeenpwned/responses.js';
+import { stealerLogsByEmail } from '../stealer-logs-by-email.js';
+
+describe('stealerLogsByEmail', () => {
+  const DOMAINS = ['netflix.com', 'spotify.com'];
+
+  describe('found', () => {
+    it('resolves with data from the remote API', () => {
+      server.use(
+        http.get('*', () => {
+          return new Response(JSON.stringify(DOMAINS));
+        }),
+      );
+
+      return expect(stealerLogsByEmail('person@example.com', { apiKey: 'k' })).resolves.toEqual(
+        DOMAINS,
+      );
+    });
+  });
+
+  describe('not found', () => {
+    it('resolves with null', () => {
+      server.use(
+        http.get('*', () => {
+          return new Response(null, { status: NOT_FOUND.status });
+        }),
+      );
+
+      return expect(stealerLogsByEmail('person@example.com')).resolves.toBeNull();
+    });
+  });
+
+  describe('apiKey option', () => {
+    it('sets the hibp-api-key header', async () => {
+      expect.assertions(1);
+      const apiKey = 'my-api-key';
+      server.use(
+        http.get('*', ({ request }) => {
+          expect(request.headers.get('hibp-api-key')).toBe(apiKey);
+          return new Response(JSON.stringify(DOMAINS));
+        }),
+      );
+
+      return stealerLogsByEmail('whatever@example.com', { apiKey });
+    });
+  });
+
+  describe('baseUrl option', () => {
+    it('is the beginning of the final URL', () => {
+      const baseUrl = 'https://my-hibp-proxy:8080';
+      server.use(
+        http.get(new RegExp(`^${baseUrl}`), () => {
+          return new Response(JSON.stringify(DOMAINS));
+        }),
+      );
+
+      return expect(stealerLogsByEmail('whatever@example.com', { baseUrl })).resolves.toEqual(
+        DOMAINS,
+      );
+    });
+  });
+
+  describe('timeoutMs option', () => {
+    it('aborts the request after the given value', () => {
+      expect.assertions(1);
+      const timeoutMs = 1;
+      server.use(
+        http.get('*', async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, timeoutMs + 1);
+          });
+          return new Response(JSON.stringify(DOMAINS));
+        }),
+      );
+
+      return expect(
+        stealerLogsByEmail('whatever@example.com', { timeoutMs }),
+      ).rejects.toMatchInlineSnapshot(`[TimeoutError: The operation was aborted due to timeout]`);
+    });
+  });
+
+  describe('userAgent option', () => {
+    it('is passed on as a request header', () => {
+      expect.assertions(1);
+      const userAgent = 'Custom UA';
+      server.use(
+        http.get('*', ({ request }) => {
+          expect(request.headers.get('User-Agent')).toBe(userAgent);
+          return new Response(JSON.stringify(DOMAINS));
+        }),
+      );
+
+      return stealerLogsByEmail('whatever@example.com', { userAgent });
+    });
+  });
+});

--- a/src/hibp.ts
+++ b/src/hibp.ts
@@ -9,6 +9,7 @@ import { pasteAccount } from './paste-account.js';
 import { pwnedPassword } from './pwned-password.js';
 import { pwnedPasswordRange } from './pwned-password-range.js';
 import { search } from './search.js';
+import { stealerLogsByEmail } from './stealer-logs-by-email.js';
 import { subscribedDomains } from './subscribed-domains.js';
 import { subscriptionStatus } from './subscription-status.js';
 
@@ -34,6 +35,7 @@ export {
   pwnedPassword,
   pwnedPasswordRange,
   search,
+  stealerLogsByEmail,
   subscribedDomains,
   subscriptionStatus,
   RateLimitError,
@@ -51,6 +53,7 @@ export interface HIBP {
   pwnedPassword: typeof pwnedPassword;
   pwnedPasswordRange: typeof pwnedPasswordRange;
   search: typeof search;
+  stealerLogsByEmail: typeof stealerLogsByEmail;
   subscribedDomains: typeof subscribedDomains;
   subscriptionStatus: typeof subscriptionStatus;
   RateLimitError: typeof RateLimitError;

--- a/src/stealer-logs-by-email.ts
+++ b/src/stealer-logs-by-email.ts
@@ -12,7 +12,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * without it will fail (unless you specify a `baseUrl` to a proxy that inserts
  * a valid API key on your behalf).
  *
- * @param {string} email the email address to query
+ * @param {string} emailAddress the email address to query
  * @param {object} [options] a configuration object
  * @param {string} [options.apiKey] an API key from
  * https://haveibeenpwned.com/API/Key (default: undefined)
@@ -52,7 +52,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * }
  */
 export function stealerLogsByEmail(
-  email: string,
+  emailAddress: string,
   options: {
     /**
      * an API key from https://haveibeenpwned.com/API/Key (default: undefined)
@@ -75,7 +75,7 @@ export function stealerLogsByEmail(
   } = {},
 ): Promise<string[] | null> {
   const { apiKey, baseUrl, timeoutMs, userAgent } = options;
-  const endpoint = `/stealerlogsbyemail/${encodeURIComponent(email)}`;
+  const endpoint = `/stealerlogsbyemail/${encodeURIComponent(emailAddress)}`;
 
   return fetchFromApi(endpoint, {
     apiKey,

--- a/src/stealer-logs-by-email.ts
+++ b/src/stealer-logs-by-email.ts
@@ -1,0 +1,86 @@
+import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
+
+/**
+ * Fetches all stealer log domains for an email address.
+ *
+ * Returns an array of domains for which stealer logs contain entries for the
+ * supplied email address.
+ *
+ * 🔑 `haveibeenpwned.com` requires an API key from
+ * https://haveibeenpwned.com/API/Key for the `stealerlogsbyemail` endpoint. The
+ * `apiKey` option here is not explicitly required, but direct requests made
+ * without it will fail (unless you specify a `baseUrl` to a proxy that inserts
+ * a valid API key on your behalf).
+ *
+ * @param {string} email the email address to query
+ * @param {object} [options] a configuration object
+ * @param {string} [options.apiKey] an API key from
+ * https://haveibeenpwned.com/API/Key (default: undefined)
+ * @param {string} [options.baseUrl] a custom base URL for the
+ * haveibeenpwned.com API endpoints (default:
+ * `https://haveibeenpwned.com/api/v3`)
+ * @param {number} [options.timeoutMs] timeout for the request in milliseconds
+ * (default: none)
+ * @param {string} [options.userAgent] a custom string to send as the User-Agent
+ * field in the request headers (default: `hibp <version>`)
+ * @returns {(Promise<string[]> | Promise<null>)} a Promise which resolves to an
+ * array of domain strings (or null if none were found), or rejects with an
+ * Error
+ * @example
+ * try {
+ *   const data = await stealerLogsByEmail("foo@bar.com", { apiKey: "my-api-key" });
+ *   if (data) {
+ *     // ...
+ *   } else {
+ *     // ...
+ *   }
+ * } catch (err) {
+ *   // ...
+ * }
+ * @example
+ * try {
+ *   const data = await stealerLogsByEmail("foo@bar.com", {
+ *     baseUrl: "https://my-hibp-proxy:8080",
+ *   });
+ *   if (data) {
+ *     // ...
+ *   } else {
+ *     // ...
+ *   }
+ * } catch (err) {
+ *   // ...
+ * }
+ */
+export function stealerLogsByEmail(
+  email: string,
+  options: {
+    /**
+     * an API key from https://haveibeenpwned.com/API/Key (default: undefined)
+     */
+    apiKey?: string;
+    /**
+     * a custom base URL for the haveibeenpwned.com API endpoints (default:
+     * `https://haveibeenpwned.com/api/v3`)
+     */
+    baseUrl?: string;
+    /**
+     * timeout for the request in milliseconds (default: none)
+     */
+    timeoutMs?: number;
+    /**
+     * a custom string to send as the User-Agent field in the request headers
+     * (default: `hibp <version>`)
+     */
+    userAgent?: string;
+  } = {},
+): Promise<string[] | null> {
+  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const endpoint = `/stealerlogsbyemail/${encodeURIComponent(email)}`;
+
+  return fetchFromApi(endpoint, {
+    apiKey,
+    baseUrl,
+    timeoutMs,
+    userAgent,
+  }) as Promise<string[] | null>;
+}


### PR DESCRIPTION
Add the `stealerLogsByEmail` module to fetch stealer log domains for an email address from the HIBP API.

Closes #529

---
<a href="https://cursor.com/background-agent?bcId=bc-6c18efa8-9c38-448e-a08d-2b418de72c9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c18efa8-9c38-448e-a08d-2b418de72c9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a new API to retrieve stealer log results for a given email, with options for API key, base URL, timeout, and user agent. Returns a list of domains or null.

- Documentation
  - Added usage docs, examples, and API reference for the new function.
  - Updated the module list in the README.

- Tests
  - Added comprehensive tests covering success, not-found, headers, base URL, and timeout scenarios.

- Chores
  - Updated bundle-size monitoring to include the new ESM entry.
  - Added a changeset for a minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->