### PR TITLE
Implement `stealerLogsByWebsiteDomain` module

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -51,6 +51,10 @@
       "maxSize": "1 kB"
     },
     {
+      "path": "dist/esm/stealer-logs-by-website-domain.js",
+      "maxSize": "1.1 kB"
+    },
+    {
       "path": "dist/esm/subscribed-domains.js",
       "maxSize": "1.1 kB"
     },

--- a/.changeset/add-stealer-logs-by-website-domain-module.md
+++ b/.changeset/add-stealer-logs-by-website-domain-module.md
@@ -1,0 +1,5 @@
+---
+'hibp': minor
+---
+
+Add `stealerLogsByWebsiteDomain` module.

--- a/API.md
+++ b/API.md
@@ -79,6 +79,16 @@ supplied email address.</p>
 without it will fail (unless you specify a <code>baseUrl</code> to a proxy that inserts
 a valid API key on your behalf).</p>
 </dd>
+<dt><a href="#stealerLogsByWebsiteDomain">stealerLogsByWebsiteDomain(websiteDomain, [options])</a> ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> | <code>Promise.&lt;null&gt;</code></dt>
+<dd><p>Fetches all stealer log email addresses for a website domain.</p>
+<p>The result is an array of strings representing email addresses found in
+stealer logs for the specified website domain (e.g., &quot;example.com&quot;).</p>
+<p>🔑 <code>haveibeenpwned.com</code> requires an API key from
+<a href="https://haveibeenpwned.com/API/Key">https://haveibeenpwned.com/API/Key</a> for the <code>stealerlogsbywebsitedomain</code>
+endpoint. The <code>apiKey</code> option here is not explicitly required, but direct
+requests made without it will fail (unless you specify a <code>baseUrl</code> to a proxy
+that inserts a valid API key on your behalf).</p>
+</dd>
 <dt><a href="#subscribedDomains">subscribedDomains([options])</a> ⇒ <code><a href="#subscribeddomain--object">Promise.&lt;Array.&lt;SubscribedDomain&gt;&gt;</a></code></dt>
 <dd><p>Fetches all subscribed domains for your HIBP account.</p>
 <p>Returns domains that have been successfully added to the Domain Search dashboard
@@ -630,6 +640,62 @@ try {
 ```js
 try {
   const data = await stealerLogsByEmail("foo@bar.com", {
+    baseUrl: "https://my-hibp-proxy:8080",
+  });
+  if (data) {
+    // ...
+  } else {
+    // ...
+  }
+} catch (err) {
+  // ...
+}
+```
+<a name="stealerLogsByWebsiteDomain"></a>
+
+## stealerLogsByWebsiteDomain(websiteDomain, [options]) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code>
+Fetches all stealer log email addresses for a website domain.
+
+The result is an array of strings representing email addresses found in
+stealer logs for the specified website domain (e.g., "example.com").
+
+🔑 `haveibeenpwned.com` requires an API key from
+https://haveibeenpwned.com/API/Key for the `stealerlogsbywebsitedomain`
+endpoint. The `apiKey` option here is not explicitly required, but direct
+requests made without it will fail (unless you specify a `baseUrl` to a proxy
+that inserts a valid API key on your behalf).
+
+**Kind**: global function  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> \| <code>Promise.&lt;null&gt;</code> - a Promise which resolves to an
+array of email addresses (or null if no results were found), or rejects with
+an Error  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| websiteDomain | <code>string</code> | the website domain to query (e.g., "example.com") |
+| [options] | <code>object</code> | a configuration object |
+| [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
+| [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
+| [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
+
+**Example**  
+```js
+try {
+  const data = await stealerLogsByWebsiteDomain("example.com", { apiKey: "my-api-key" });
+  if (data) {
+    // ["andy@gmail.com", "jane@gmail.com"]
+  } else {
+    // no results
+  }
+} catch (err) {
+  // ...
+}
+```
+**Example**  
+```js
+try {
+  const data = await stealerLogsByWebsiteDomain("example.com", {
     baseUrl: "https://my-hibp-proxy:8080",
   });
   if (data) {

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following modules are available:
 - [pwnedPasswordRange](API.md#pwnedpasswordrange)
 - [search](API.md#search)
 - [stealerLogsByEmail](API.md#stealerlogsbyemail)
+- [stealerLogsByWebsiteDomain](API.md#stealerlogsbywebsitedomain)
 - [subscribedDomains](API.md#subscribeddomains)
 - [subscriptionStatus](API.md#subscriptionstatus)
 

--- a/src/__tests__/hibp.test.ts
+++ b/src/__tests__/hibp.test.ts
@@ -17,6 +17,7 @@ describe('hibp', () => {
         "pwnedPasswordRange": [Function],
         "search": [Function],
         "stealerLogsByEmail": [Function],
+        "stealerLogsByWebsiteDomain": [Function],
         "subscribedDomains": [Function],
         "subscriptionStatus": [Function],
       }

--- a/src/__tests__/stealer-logs-by-website-domain.test.ts
+++ b/src/__tests__/stealer-logs-by-website-domain.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { http } from 'msw';
+import { server } from '../../mocks/server.js';
+import { NOT_FOUND } from '../api/haveibeenpwned/responses.js';
+import { stealerLogsByWebsiteDomain } from '../stealer-logs-by-website-domain.js';
+
+describe('stealerLogsByWebsiteDomain', () => {
+  const RESULTS = ['andy@gmail.com', 'jane@gmail.com'];
+
+  describe('found', () => {
+    it('resolves with data from the remote API', () => {
+      server.use(
+        http.get('*', () => {
+          return new Response(JSON.stringify(RESULTS));
+        }),
+      );
+
+      return expect(stealerLogsByWebsiteDomain('example.com', { apiKey: 'k' })).resolves.toEqual(
+        RESULTS,
+      );
+    });
+  });
+
+  describe('not found', () => {
+    it('resolves with null', () => {
+      server.use(
+        http.get('*', () => {
+          return new Response(null, { status: NOT_FOUND.status });
+        }),
+      );
+
+      return expect(stealerLogsByWebsiteDomain('example.com')).resolves.toBeNull();
+    });
+  });
+
+  describe('apiKey option', () => {
+    it('sets the hibp-api-key header', async () => {
+      expect.assertions(1);
+      const apiKey = 'my-api-key';
+      server.use(
+        http.get('*', ({ request }) => {
+          expect(request.headers.get('hibp-api-key')).toBe(apiKey);
+          return new Response(JSON.stringify(RESULTS));
+        }),
+      );
+
+      return stealerLogsByWebsiteDomain('example.com', { apiKey });
+    });
+  });
+
+  describe('baseUrl option', () => {
+    it('is the beginning of the final URL', () => {
+      const baseUrl = 'https://my-hibp-proxy:8080';
+      server.use(
+        http.get(new RegExp(`^${baseUrl}`), () => {
+          return new Response(JSON.stringify(RESULTS));
+        }),
+      );
+
+      return expect(stealerLogsByWebsiteDomain('example.com', { baseUrl })).resolves.toEqual(
+        RESULTS,
+      );
+    });
+  });
+
+  describe('timeoutMs option', () => {
+    it('aborts the request after the given value', () => {
+      expect.assertions(1);
+      const timeoutMs = 1;
+      server.use(
+        http.get('*', async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, timeoutMs + 1);
+          });
+          return new Response(JSON.stringify(RESULTS));
+        }),
+      );
+
+      return expect(
+        stealerLogsByWebsiteDomain('example.com', { timeoutMs }),
+      ).rejects.toMatchInlineSnapshot(`[TimeoutError: The operation was aborted due to timeout]`);
+    });
+  });
+
+  describe('userAgent option', () => {
+    it('is passed on as a request header', () => {
+      expect.assertions(1);
+      const userAgent = 'Custom UA';
+      server.use(
+        http.get('*', ({ request }) => {
+          expect(request.headers.get('User-Agent')).toBe(userAgent);
+          return new Response(JSON.stringify(RESULTS));
+        }),
+      );
+
+      return stealerLogsByWebsiteDomain('example.com', { userAgent });
+    });
+  });
+});

--- a/src/hibp.ts
+++ b/src/hibp.ts
@@ -10,6 +10,7 @@ import { pwnedPassword } from './pwned-password.js';
 import { pwnedPasswordRange } from './pwned-password-range.js';
 import { search } from './search.js';
 import { stealerLogsByEmail } from './stealer-logs-by-email.js';
+import { stealerLogsByWebsiteDomain } from './stealer-logs-by-website-domain.js';
 import { subscribedDomains } from './subscribed-domains.js';
 import { subscriptionStatus } from './subscription-status.js';
 
@@ -36,6 +37,7 @@ export {
   pwnedPasswordRange,
   search,
   stealerLogsByEmail,
+  stealerLogsByWebsiteDomain,
   subscribedDomains,
   subscriptionStatus,
   RateLimitError,
@@ -54,6 +56,7 @@ export interface HIBP {
   pwnedPasswordRange: typeof pwnedPasswordRange;
   search: typeof search;
   stealerLogsByEmail: typeof stealerLogsByEmail;
+  stealerLogsByWebsiteDomain: typeof stealerLogsByWebsiteDomain;
   subscribedDomains: typeof subscribedDomains;
   subscriptionStatus: typeof subscriptionStatus;
   RateLimitError: typeof RateLimitError;

--- a/src/stealer-logs-by-website-domain.ts
+++ b/src/stealer-logs-by-website-domain.ts
@@ -1,0 +1,86 @@
+import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
+
+/**
+ * Fetches all stealer log email addresses for a website domain.
+ *
+ * The result is an array of strings representing email addresses found in
+ * stealer logs for the specified website domain (e.g., "example.com").
+ *
+ * 🔑 `haveibeenpwned.com` requires an API key from
+ * https://haveibeenpwned.com/API/Key for the `stealerlogsbywebsitedomain`
+ * endpoint. The `apiKey` option here is not explicitly required, but direct
+ * requests made without it will fail (unless you specify a `baseUrl` to a proxy
+ * that inserts a valid API key on your behalf).
+ *
+ * @param {string} websiteDomain the website domain to query (e.g., "example.com")
+ * @param {object} [options] a configuration object
+ * @param {string} [options.apiKey] an API key from
+ * https://haveibeenpwned.com/API/Key (default: undefined)
+ * @param {string} [options.baseUrl] a custom base URL for the
+ * haveibeenpwned.com API endpoints (default:
+ * `https://haveibeenpwned.com/api/v3`)
+ * @param {number} [options.timeoutMs] timeout for the request in milliseconds
+ * (default: none)
+ * @param {string} [options.userAgent] a custom string to send as the User-Agent
+ * field in the request headers (default: `hibp <version>`)
+ * @returns {(Promise<string[]> | Promise<null>)} a Promise which resolves to an
+ * array of email addresses (or null if no results were found), or rejects with
+ * an Error
+ * @example
+ * try {
+ *   const data = await stealerLogsByWebsiteDomain("example.com", { apiKey: "my-api-key" });
+ *   if (data) {
+ *     // ["andy@gmail.com", "jane@gmail.com"]
+ *   } else {
+ *     // no results
+ *   }
+ * } catch (err) {
+ *   // ...
+ * }
+ * @example
+ * try {
+ *   const data = await stealerLogsByWebsiteDomain("example.com", {
+ *     baseUrl: "https://my-hibp-proxy:8080",
+ *   });
+ *   if (data) {
+ *     // ...
+ *   } else {
+ *     // ...
+ *   }
+ * } catch (err) {
+ *   // ...
+ * }
+ */
+export function stealerLogsByWebsiteDomain(
+  websiteDomain: string,
+  options: {
+    /**
+     * an API key from https://haveibeenpwned.com/API/Key (default: undefined)
+     */
+    apiKey?: string;
+    /**
+     * a custom base URL for the haveibeenpwned.com API endpoints (default:
+     * `https://haveibeenpwned.com/api/v3`)
+     */
+    baseUrl?: string;
+    /**
+     * timeout for the request in milliseconds (default: none)
+     */
+    timeoutMs?: number;
+    /**
+     * a custom string to send as the User-Agent field in the request headers
+     * (default: `hibp <version>`)
+     */
+    userAgent?: string;
+  } = {},
+): Promise<string[] | null> {
+  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const endpoint = `/stealerlogsbywebsitedomain/${encodeURIComponent(websiteDomain)}`;
+
+  return fetchFromApi(endpoint, {
+    apiKey,
+    baseUrl,
+    timeoutMs,
+    userAgent,
+  }) as Promise<string[] | null>;
+}


### PR DESCRIPTION
Add `stealerLogsByWebsiteDomain` module to fetch email addresses from stealer logs for a given website domain.

Closes #528

---
<a href="https://cursor.com/background-agent?bcId=bc-c662b1a6-1e45-4303-9bb4-e48e29850636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c662b1a6-1e45-4303-9bb4-e48e29850636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added capability to retrieve stealer log email addresses by website domain, with options for API key, base URL, timeout, and user agent. Returns a list or null when not found.

- Documentation
  - Updated API docs and README with usage examples and configuration details for the new capability.

- Tests
  - Added comprehensive tests covering success, not-found, headers, base URL handling, and timeout behavior.

- Chores
  - Updated bundle size monitoring to include the new module with a defined size budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->