### PR TITLE
Implement user-controlled request cancellation

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -68,7 +68,7 @@
     },
     {
       "path": "dist/esm/pwned-password-range.js",
-      "maxSize": "1.4 kB"
+      "maxSize": "1.5 kB"
     },
     {
       "path": "dist/esm/search.js",
@@ -84,11 +84,11 @@
     },
     {
       "path": "dist/esm/stealer-logs-by-website-domain.js",
-      "maxSize": "1 kB"
+      "maxSize": "1.1 kB"
     },
     {
       "path": "dist/esm/subscribed-domains.js",
-      "maxSize": "1.1 kB"
+      "maxSize": "1.2 kB"
     },
     {
       "path": "dist/esm/subscription-status.js",

--- a/.changeset/abort-signal.md
+++ b/.changeset/abort-signal.md
@@ -1,0 +1,5 @@
+---
+"hibp": minor
+---
+
+Add `signal` option to all modules for user-controlled request cancellation via `AbortSignal`.

--- a/API.md
+++ b/API.md
@@ -170,6 +170,7 @@ with an Error
 | [options] | <code>object</code> | a configuration object |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -209,6 +210,7 @@ an Error
 | [options.domain] | <code>string</code> | a domain by which to filter the results (default: all domains) |
 | [options.includeUnverified] | <code>boolean</code> | include "unverified" breaches in the results (default: true) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.truncate] | <code>boolean</code> | truncate the results to only include the name of each breach (default: true) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
@@ -288,6 +290,7 @@ results were found), or rejects with an Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -318,6 +321,7 @@ objects (an empty array if no breaches were found), or rejects with an Error
 | [options.domain] | <code>string</code> | a domain by which to filter the results (default: all domains) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -361,6 +365,7 @@ Error
 | [options] | <code>object</code> | a configuration object |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -391,6 +396,7 @@ with an Error
 | [options] | <code>object</code> | a configuration object |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -429,6 +435,7 @@ Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -486,6 +493,7 @@ password data set, or rejects with an Error
 | [options.mode] | <code>&#x27;sha1&#x27;</code> \| <code>&#x27;ntlm&#x27;</code> | return SHA-1 or NTLM hashes (default: `sha1`) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -531,6 +539,7 @@ the password has been exposed in a breach, or rejects with an Error
 | [options.addPadding] | <code>boolean</code> | ask the remote API to add padding to the response to obscure the password prefix (default: `false`) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -580,6 +589,7 @@ rejects with an Error
 | [options.truncate] | <code>boolean</code> | truncate the breach results to only include the name of each breach (default: true) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -639,6 +649,7 @@ which resolves to an object mapping aliases to stealer log email domain arrays
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -680,6 +691,7 @@ Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -736,6 +748,7 @@ an Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -791,6 +804,7 @@ subscribed domain objects (an empty array if none), or rejects with an Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  
@@ -834,6 +848,7 @@ subscription status object, or rejects with an Error
 | [options.apiKey] | <code>string</code> | an API key from https://haveibeenpwned.com/API/Key (default: undefined) |
 | [options.baseUrl] | <code>string</code> | a custom base URL for the haveibeenpwned.com API endpoints (default: `https://haveibeenpwned.com/api/v3`) |
 | [options.timeoutMs] | <code>number</code> | timeout for the request in milliseconds (default: none) |
+| [options.signal] | <code>AbortSignal</code> | an AbortSignal to cancel the request (default: none) |
 | [options.userAgent] | <code>string</code> | a custom string to send as the User-Agent field in the request headers (default: `hibp <version>`) |
 
 **Example**  

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ browser.
 - Get all subscribed domains 🔑
 - Get your subscription status 🔑
 - All queries return a Promise
+- Provide your own `AbortSignal` to cancel in-flight requests
 - Available server-side (e.g., Node.js) and client-side (browser)
 - Written in TypeScript, so all modules come fully typed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ browser.
 - Get all subscribed domains 🔑
 - Get your subscription status 🔑
 - All queries return a Promise
+- Provide your own `AbortSignal` to cancel in-flight requests
 - Available server-side (e.g., Node.js) and client-side (browser)
 - Written in TypeScript, so all modules come fully typed
 

--- a/src/api/base-fetch.ts
+++ b/src/api/base-fetch.ts
@@ -1,11 +1,22 @@
 // @ts-ignore - package-info.js is generated
 import { PACKAGE_NAME, PACKAGE_VERSION } from './haveibeenpwned/package-info.js';
 
+function buildSignal(timeoutMs?: number, signal?: AbortSignal): AbortSignal | undefined {
+  const signals: AbortSignal[] = [];
+  if (timeoutMs) signals.push(AbortSignal.timeout(timeoutMs));
+  if (signal) signals.push(signal);
+
+  if (signals.length === 0) return undefined;
+  if (signals.length === 1) return signals[0];
+  return AbortSignal.any(signals);
+}
+
 export async function baseFetch({
   baseUrl,
   endpoint,
   headers,
   timeoutMs,
+  signal,
   userAgent,
   queryParams,
 }: {
@@ -13,12 +24,13 @@ export async function baseFetch({
   endpoint: string;
   headers?: Record<string, string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
   userAgent?: string;
   queryParams?: Record<string, string>;
 }): Promise<Response> {
   const requestInit: RequestInit = {
     headers: buildHeaders(userAgent, headers),
-    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
+    signal: buildSignal(timeoutMs, signal),
   };
 
   const url = buildUrl(baseUrl, endpoint, queryParams);

--- a/src/api/haveibeenpwned/fetch-from-api.ts
+++ b/src/api/haveibeenpwned/fetch-from-api.ts
@@ -54,6 +54,7 @@ function blockedWithRayId(rayId: string) {
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<ApiData>} a Promise which resolves to the data resulting
@@ -66,10 +67,17 @@ export async function fetchFromApi(
     apiKey?: string;
     baseUrl?: string;
     timeoutMs?: number;
+    signal?: AbortSignal;
     userAgent?: string;
   } = {},
 ): Promise<ApiData> {
-  const { apiKey, baseUrl = 'https://haveibeenpwned.com/api/v3', timeoutMs, userAgent } = options;
+  const {
+    apiKey,
+    baseUrl = 'https://haveibeenpwned.com/api/v3',
+    timeoutMs,
+    signal,
+    userAgent,
+  } = options;
 
   const headers: Record<string, string> = {};
   if (apiKey) headers['HIBP-API-Key'] = apiKey;
@@ -79,6 +87,7 @@ export async function fetchFromApi(
     endpoint,
     headers,
     timeoutMs,
+    signal,
     userAgent,
   });
 

--- a/src/api/pwnedpasswords/fetch-from-api.ts
+++ b/src/api/pwnedpasswords/fetch-from-api.ts
@@ -15,6 +15,7 @@ import { BAD_REQUEST } from './responses.js';
  * pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @param {boolean} [options.addPadding] ask the remote API to add padding to
@@ -29,6 +30,7 @@ export async function fetchFromApi(
   options: {
     baseUrl?: string;
     timeoutMs?: number;
+    signal?: AbortSignal;
     userAgent?: string;
     addPadding?: boolean;
     mode?: 'sha1' | 'ntlm';
@@ -37,6 +39,7 @@ export async function fetchFromApi(
   const {
     baseUrl = 'https://api.pwnedpasswords.com',
     timeoutMs,
+    signal,
     userAgent,
     addPadding = false,
     mode = 'sha1',
@@ -50,6 +53,7 @@ export async function fetchFromApi(
     endpoint,
     headers,
     timeoutMs,
+    signal,
     userAgent,
     queryParams: { mode },
   });

--- a/src/breach.ts
+++ b/src/breach.ts
@@ -34,6 +34,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<Breach>|Promise<null>)} a Promise which resolves to an
@@ -63,6 +64,10 @@ export function breach(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)

--- a/src/breached-account.ts
+++ b/src/breached-account.ts
@@ -20,6 +20,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * the results (default: true)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {boolean} [options.truncate] truncate the results to only include
  * the name of each breach (default: true)
  * @param {string} [options.baseUrl] a custom base URL for the
@@ -92,6 +93,10 @@ export function breachedAccount(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * truncate the results to only include the name of each breach (default:
      * true)
      */
@@ -113,6 +118,7 @@ export function breachedAccount(
     domain,
     includeUnverified = true,
     timeoutMs,
+    signal,
     truncate = true,
     baseUrl,
     userAgent,
@@ -136,6 +142,7 @@ export function breachedAccount(
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<Breach[] | null>;
 }

--- a/src/breached-domain.ts
+++ b/src/breached-domain.ts
@@ -31,6 +31,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<BreachedDomainsByEmailAlias> | Promise<null>)} a Promise which
@@ -65,19 +66,24 @@ export function breachedDomain(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<BreachedDomainsByEmailAlias | null> {
-  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = `/breacheddomain/${encodeURIComponent(domain)}`;
 
   return fetchFromApi(endpoint, {
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<BreachedDomainsByEmailAlias | null>;
 }

--- a/src/breaches.ts
+++ b/src/breaches.ts
@@ -12,6 +12,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<Breach[]>} a Promise which resolves to an array of breach
@@ -55,13 +56,17 @@ export function breaches(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<Breach[]> {
-  const { domain, baseUrl, timeoutMs, userAgent } = options;
+  const { domain, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = '/breaches?';
   const params: string[] = [];
 
@@ -72,6 +77,7 @@ export function breaches(
   return fetchFromApi(`${endpoint}${params.join('&')}`, {
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<Breach[]>;
 }

--- a/src/data-classes.ts
+++ b/src/data-classes.ts
@@ -9,6 +9,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<string[]> | Promise<null>)} a Promise which resolves to an
@@ -37,6 +38,10 @@ export function dataClasses(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)

--- a/src/latest-breach.ts
+++ b/src/latest-breach.ts
@@ -10,6 +10,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<Breach>|Promise<null>)} a Promise which resolves to an
@@ -38,6 +39,10 @@ export function latestBreach(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)

--- a/src/paste-account.ts
+++ b/src/paste-account.ts
@@ -30,6 +30,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<Paste[]> | Promise<null>)} a Promise which resolves to an
@@ -76,6 +77,10 @@ export function pasteAccount(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)

--- a/src/pwned-password-range.ts
+++ b/src/pwned-password-range.ts
@@ -30,6 +30,7 @@ export type PwnedPasswordSuffixes = Record<string, number>;
  * pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<PwnedPasswordSuffixes>} a Promise which resolves to an
@@ -81,17 +82,22 @@ export async function pwnedPasswordRange(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<PwnedPasswordSuffixes> {
-  const { baseUrl, timeoutMs, userAgent, addPadding = false, mode = 'sha1' } = options;
+  const { baseUrl, timeoutMs, signal, userAgent, addPadding = false, mode = 'sha1' } = options;
 
   const data = await fetchFromApi(`/range/${encodeURIComponent(prefix)}`, {
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
     addPadding,
     mode,

--- a/src/pwned-password.ts
+++ b/src/pwned-password.ts
@@ -13,6 +13,7 @@ import { pwnedPasswordRange } from './pwned-password-range.js';
  * pwnedpasswords.com API endpoints (default: `https://api.pwnedpasswords.com`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<number>} a Promise which resolves to the number of times
@@ -48,6 +49,10 @@ export async function pwnedPassword(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)

--- a/src/search.ts
+++ b/src/search.ts
@@ -43,6 +43,7 @@ export interface SearchResults {
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the
  * User-Agent field in the request headers (default: `hibp <version>`)
  * @returns {Promise<SearchResults>} a Promise which resolves to an object
@@ -102,13 +103,17 @@ export async function search(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<SearchResults> {
-  const { apiKey, domain, truncate = true, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, domain, truncate = true, baseUrl, timeoutMs, signal, userAgent } = options;
 
   const [breaches, pastes] = await Promise.all([
     breachedAccount(account, {
@@ -117,11 +122,12 @@ export async function search(
       truncate,
       baseUrl,
       timeoutMs,
+      signal,
       userAgent,
     }),
     // This email regex is garbage but it seems to be what the API uses:
     /^.+@.+$/.test(account)
-      ? pasteAccount(account, { apiKey, baseUrl, timeoutMs, userAgent })
+      ? pasteAccount(account, { apiKey, baseUrl, timeoutMs, signal, userAgent })
       : null,
   ]);
 

--- a/src/stealer-logs-by-email-domain.ts
+++ b/src/stealer-logs-by-email-domain.ts
@@ -32,6 +32,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<StealerLogDomainsByEmailAlias> | Promise<null>)} a Promise
@@ -66,19 +67,24 @@ export function stealerLogsByEmailDomain(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<StealerLogDomainsByEmailAlias | null> {
-  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = `/stealerlogsbyemaildomain/${encodeURIComponent(emailDomain)}`;
 
   return fetchFromApi(endpoint, {
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<StealerLogDomainsByEmailAlias | null>;
 }

--- a/src/stealer-logs-by-email.ts
+++ b/src/stealer-logs-by-email.ts
@@ -21,6 +21,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<string[]> | Promise<null>)} a Promise which resolves to an
@@ -68,19 +69,24 @@ export function stealerLogsByEmail(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<string[] | null> {
-  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = `/stealerlogsbyemail/${encodeURIComponent(emailAddress)}`;
 
   return fetchFromApi(endpoint, {
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<string[] | null>;
 }

--- a/src/stealer-logs-by-website-domain.ts
+++ b/src/stealer-logs-by-website-domain.ts
@@ -21,6 +21,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {(Promise<string[]> | Promise<null>)} a Promise which resolves to an
@@ -68,19 +69,24 @@ export function stealerLogsByWebsiteDomain(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<string[] | null> {
-  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = `/stealerlogsbywebsitedomain/${encodeURIComponent(websiteDomain)}`;
 
   return fetchFromApi(endpoint, {
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<string[] | null>;
 }

--- a/src/subscribed-domains.ts
+++ b/src/subscribed-domains.ts
@@ -33,6 +33,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<SubscribedDomain[]>} a Promise which resolves to an array of
@@ -70,19 +71,24 @@ export function subscribedDomains(
      */
     timeoutMs?: number;
     /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
+    /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)
      */
     userAgent?: string;
   } = {},
 ): Promise<SubscribedDomain[]> {
-  const { apiKey, baseUrl, timeoutMs, userAgent } = options;
+  const { apiKey, baseUrl, timeoutMs, signal, userAgent } = options;
   const endpoint = '/subscribeddomains';
 
   return fetchFromApi(endpoint, {
     apiKey,
     baseUrl,
     timeoutMs,
+    signal,
     userAgent,
   }) as Promise<SubscribedDomain[]>;
 }

--- a/src/subscription-status.ts
+++ b/src/subscription-status.ts
@@ -30,6 +30,7 @@ import { fetchFromApi } from './api/haveibeenpwned/fetch-from-api.js';
  * `https://haveibeenpwned.com/api/v3`)
  * @param {number} [options.timeoutMs] timeout for the request in milliseconds
  * (default: none)
+ * @param {AbortSignal} [options.signal] an AbortSignal to cancel the request (default: none)
  * @param {string} [options.userAgent] a custom string to send as the User-Agent
  * field in the request headers (default: `hibp <version>`)
  * @returns {Promise<SubscriptionStatus>} a Promise which resolves to a
@@ -66,6 +67,10 @@ export async function subscriptionStatus(
      * timeout for the request in milliseconds (default: none)
      */
     timeoutMs?: number;
+    /**
+     * an AbortSignal to cancel the request (default: none)
+     */
+    signal?: AbortSignal;
     /**
      * a custom string to send as the User-Agent field in the request headers
      * (default: `hibp <version>`)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to provide their own `AbortSignal` to cancel in-flight API requests, improving control over request cancellation. The change is documented in the API and README files, and is supported across all modules. Additionally, related tests and minor bundle size limit adjustments are included.

Key changes:

**Feature: Request Cancellation Support**
* Added a `signal` option (of type `AbortSignal`) to all API modules, enabling user-controlled cancellation of requests. This is handled in `baseFetch` via a new `buildSignal` function that combines timeout and user-provided signals. [[1]](diffhunk://#diff-52d8d75524900924ad546251b298aabe1695d92e3b81fe3706b9389b9a693e73R4-R33) [[2]](diffhunk://#diff-cc743832d9753de12e817e7a602b36ead3629552f1942cc7b645d691ebe3fc56R57) [[3]](diffhunk://#diff-cc743832d9753de12e817e7a602b36ead3629552f1942cc7b645d691ebe3fc56R70-R80) [[4]](diffhunk://#diff-cc743832d9753de12e817e7a602b36ead3629552f1942cc7b645d691ebe3fc56R90) [[5]](diffhunk://#diff-69c3ffe2bf85a02892bc59274fa3f7d07e4854803345600f851e5c8e45a3f008R1-R5)

**Documentation Updates**
* Updated `API.md`, `README.md`, and `docs/index.md` to document the new `signal` option and explain its usage for cancelling requests. [[1]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R173) [[2]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R213) [[3]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R293) [[4]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R324) [[5]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R368) [[6]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R399) [[7]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R438) [[8]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R496) [[9]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R542) [[10]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R592) [[11]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R652) [[12]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R694) [[13]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R751) [[14]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R807) [[15]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R851) [[16]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55) [[17]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R52)

**Testing**
* Added comprehensive tests for `baseFetch` to verify correct behavior when using `AbortSignal`, including scenarios with only timeout, only signal, both, and neither. [[1]](diffhunk://#diff-0286ab0011cc36dd441c0474d4bd12b68d3a1cc0e18d0943f8f9386f4d88af31L1-R4) [[2]](diffhunk://#diff-0286ab0011cc36dd441c0474d4bd12b68d3a1cc0e18d0943f8f9386f4d88af31R101-R181)

**Configuration**
* Increased bundle size limits in `.bundlewatch.config.json` for several files to accommodate the additional logic for signal support. [[1]](diffhunk://#diff-31de063a290a3a747822bb84b148e2deab3f2e786d7ae326a8a961ace2584014L71-R71) [[2]](diffhunk://#diff-31de063a290a3a747822bb84b148e2deab3f2e786d7ae326a8a961ace2584014L87-R91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AbortSignal support across all API functions, enabling users to cancel in-flight requests

* **Documentation**
  * Updated API documentation and guides with the new signal option

* **Chores**
  * Adjusted bundle size thresholds; documented minor release changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->