### PR TITLE
chore: reduce pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ allowBuilds:
   msw: false
   unrs-resolver: false
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   # Renovate security update: esbuild@0.28.1
   - esbuild@0.28.1


### PR DESCRIPTION
Sets pnpm's minimum release age to 1440 minutes.